### PR TITLE
64bit numbers parsing changes

### DIFF
--- a/lib/packet_elements/flow_set_elements/data_set/field_specifier.js
+++ b/lib/packet_elements/flow_set_elements/data_set/field_specifier.js
@@ -49,10 +49,23 @@ var DataSetFieldSpecifier = function (buffer, cachedField, params) {
                 }
             } else if (cachedFieldLength == 8) {
                 self.sizeInBytes = 8;
-                var UINT64 = bignum.fromBuffer(buffer.slice(0, 8)).toString();
-                self.fieldValue = "" + UINT64
-                if (shouldParse)
+                if (shouldParse) {
+                    try {
+                        self.fieldValueParsed = "" + ByteParser.parseByType(dataType, buffer.slice(0, 8))
+                        self.fieldValue = self.fieldValueParsed;
+                    }
+                    catch (e) {
+                        var UINT64 = bignum.fromBuffer(buffer.slice(0, 8)).toString();
+                        self.fieldValue = "" + UINT64
+                        self.fieldValueParsed = "" + UINT64;
+                    }
+                }
+                else {
+                    var UINT64 = bignum.fromBuffer(buffer.slice(0, 8)).toString();
+                    self.fieldValue = "" + UINT64
                     self.fieldValueParsed = "" + UINT64;
+                }
+
             } else if (cachedFieldLength == 16) {
                 self.sizeInBytes = 16;
                 var uint8Array = new Uint8Array(16);

--- a/lib/utils/byte_parsers.js
+++ b/lib/utils/byte_parsers.js
@@ -2,9 +2,13 @@ var SUPPORTED_TYPES = [
     'String',
     'ipv4Address',
     'ipv6Address',
-    'Boolean'
+    'Boolean',
+    'Hex',
+    'unsigned64'
 ];
 var ipv6 = require('ip-address').Address6;
+var bignum = require('bignum');
+
 var ByteParser = function(){
     var self = this;
     this.parseByType = function(type,int){
@@ -17,6 +21,12 @@ var ByteParser = function(){
                 return self.ipv6Address(int);
             else if(type == 'Boolean')
                 return self.Boolean(int);
+            else if(type == 'Hex') {
+                return self.Hex(int);
+            }
+            else if(type == 'unsigned64'){
+                return self.BigNum(int);
+            }
         }else{
             throw new Error(`Parsing by type '${type}' not supported : `)
         }
@@ -24,6 +34,14 @@ var ByteParser = function(){
     this.String = function(buffer){
         return null;
     };
+
+    this.Hex = function (buffer) {
+        return buffer.toString('hex');
+    };
+
+    this.BigNum = function (buffer) {
+        return bignum.fromBuffer(buffer.slice(0, 8)).toString();
+    }
 
     this.ipv4Address = function(int){
         var part1 = int & 255;

--- a/static/ipfix_entities.json
+++ b/static/ipfix_entities.json
@@ -1442,7 +1442,7 @@
     "148": {
       "ElementID": "148",
       "Name": "flowId",
-      "DataType": "unsigned64",
+      "DataType": "Hex",
       "Data Type Semantics": "identifier",
       "Status": "current",
       "Units": "",


### PR DESCRIPTION
To optimize performance, when should-parse is enabled, these are read as hex values.